### PR TITLE
Add docker support

### DIFF
--- a/.github/workflows/docker-build-test.yml
+++ b/.github/workflows/docker-build-test.yml
@@ -11,4 +11,4 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Build Docker image
-        run: docker build -t reddlinks -f docker/Dockerfile .
+        run: docker build -t reddlinks -f docker/Dockerfile-ci .

--- a/.github/workflows/docker-build-test.yml
+++ b/.github/workflows/docker-build-test.yml
@@ -1,0 +1,14 @@
+name: docker-build
+
+on: [push]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build Docker image
+        run: docker build -t reddlinks -f docker/Dockerfile .

--- a/.github/workflows/gobuild.yml
+++ b/.github/workflows/gobuild.yml
@@ -1,0 +1,20 @@
+name: gobuild
+
+on: [push]
+
+permissions:
+  contents: read
+
+jobs:
+  gobuild:
+    name: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v4
+        with:
+          go-version: '1.21'
+          cache: false
+      - name: Build the project
+        run: |
+          go build

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ prep: fmt mod vet lint test
 
 compile: clean
 	@mkdir -p build/
-	@sed -i "s/noVersion/$(VERSION)/g" main.go
+	@sed "s/noVersion/$(VERSION)/g" main.go > main.go.alt && mv main.go.alt main.go
 	@go build -o build/
 
 fmt:

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@
 <!-- PROJECT SHIELDS -->
 ![GitHub Workflow Status (with event)](https://img.shields.io/github/actions/workflow/status/redds-be/reddlinks/golangci-lint.yml?label=Golangci-lint)
 ![GitHub Workflow Status (with event)](https://img.shields.io/github/actions/workflow/status/redds-be/reddlinks/gotest.yml?label=Go%20test)
+![GitHub Workflow Status (with event)](https://img.shields.io/github/actions/workflow/status/redds-be/reddlinks/gobuild.yml?label=Go%20build)
+![GitHub Workflow Status (with event)](https://img.shields.io/github/actions/workflow/status/redds-be/reddlinks/docker-build-test.yml?label=Docker%20build)
 ![GitHub pull requests](https://img.shields.io/github/issues-pr/redds-be/reddlinks)
 ![GitHub issues](https://img.shields.io/github/issues/redds-be/reddlinks)
 ![GitHub License](https://img.shields.io/github/license/redds-be/reddlinks)

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -28,31 +28,17 @@ REDDLINKS_INSTANCE_URL=<http/https>://<sub.domain.tld><:port>/
 # DATABASE CONFIG #
 ###################
 
-POSTGRES
-########
-
 ## <postgres username>: Postgres user username.
 ## <postgres user password>: The postgres user's very secret and complicated password (can be a hash if postgres is configured for it).
 ## <postgres host>: The host on which postgres runs on can be 'localhost' or a unix socket if running locally.
 ## <postgres port>: The port of the postgres server, by default, the port is 5432.
 ## <postgres database>: The name of your postgres database.
 ## For more details or examples, please check this documentation: <https://www.postgresql.org/docs/14/libpq-connect.html#id-1.7.3.8.3.6>
-#REDDLINKS_DB_TYPE=postgres
-#REDDLINKS_DB_STRING=postgres://<postgres username>:<postgres user password>@<postgres host>:<postgres port>/<postgres database>
-
-FOR DOCKER
-##########
-#PG_USER=rluser
-#PG_PASS=
-#PG_DB=rldb
-
-SQLITE
-######
-
-## <database name>: The name of your sqlite database.
-## For more details including cache or authentication, please check this documentation: <https://github.com/mattn/go-sqlite3#connection-string>
-#REDDLINKS_DB_TYPE=sqlite3
-#REDDLINKS_DB_STRING=<database name>.db
+REDDLINKS_PG_USER=rluser
+REDDLINKS_PG_PASS=
+REDDLINKS_PG_DB=rldb
+REDDLINKS_DB_TYPE=postgres
+REDDLINKS_DB_STRING=postgres://$REDDLINKS_PG_USER:$REDDLINKS_PG_PASS@postgresql:5432/$REDDLINKS_PG_DB?sslmode=disable
 
 ## Time between database cleanup in minutes, 1 for 1 minute, 60 for 1 hour, 120 for 2 hours, ...
 REDDLINKS_TIME_BETWEEN_DB_CLEANUPS=<time in minutes>

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,24 @@
+FROM golang:1.21-alpine3.19
+
+RUN apk update && apk add --no-cache build-base git
+
+EXPOSE 8080
+
+RUN mkdir /opt/reddlinks
+RUN adduser -D rluser
+
+WORKDIR /opt/reddlinks
+
+COPY go.mod .
+COPY go.sum .
+RUN go mod download
+RUN go mod vendor
+COPY . .
+RUN mv docker/.env .
+
+RUN chown -R rluser:rluser /opt/reddlinks
+RUN git config --global --add safe.directory /opt/reddlinks
+RUN make
+RUN mv build/reddlinks /usr/local/bin/
+
+ENTRYPOINT ["reddlinks"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -11,8 +11,9 @@ WORKDIR /opt/reddlinks
 
 COPY go.mod .
 COPY go.sum .
-RUN go mod download
 RUN go mod vendor
+RUN go mod tidy
+RUN go mod download
 COPY . .
 
 RUN chown -R rluser:rluser /opt/reddlinks

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,14 +7,9 @@ EXPOSE 8080
 RUN mkdir /opt/reddlinks
 RUN adduser -D rluser
 
+ADD . /opt/reddlinks
 WORKDIR /opt/reddlinks
-
-COPY go.mod .
-COPY go.sum .
-RUN go mod vendor
-RUN go mod tidy
-RUN go mod download
-COPY . .
+RUN go get github.com/redds-be/reddlinks
 
 RUN chown -R rluser:rluser /opt/reddlinks
 RUN git config --global --add safe.directory /opt/reddlinks

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,7 +14,6 @@ COPY go.sum .
 RUN go mod download
 RUN go mod vendor
 COPY . .
-RUN mv docker/.env .
 
 RUN chown -R rluser:rluser /opt/reddlinks
 RUN git config --global --add safe.directory /opt/reddlinks

--- a/docker/Dockerfile-ci
+++ b/docker/Dockerfile-ci
@@ -1,0 +1,15 @@
+FROM golang:1.21-alpine3.19
+
+RUN apk update && apk add --no-cache build-base git
+
+EXPOSE 8080
+
+RUN mkdir /opt/reddlinks
+ADD . /opt/reddlinks
+WORKDIR /opt/reddlinks
+RUN go get github.com/redds-be/reddlinks
+
+RUN go build
+RUN mv reddlinks /usr/local/bin/
+
+ENTRYPOINT ["reddlinks"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,52 @@
+# Deploy reddlinks with docker
+
+It is strongly recommended to use [docker compose]()
+
+## Docker
+
+The dockerfile in this directory can be used to build a docker container for reddlinks.
+
+By default, the Dockerfile uses the port 8080 (EXPOSE 8080), feel free to change it for a more convenient one.
+
+From reddlinks's root directory:
+
+```console
+docker build -t reddlinks -f docker/Dockerfile .
+```
+
+From the `docker/` directory:
+
+```console
+docker build -t reddlinks -f Dockerfile ../
+```
+
+Run the container:
+
+```console
+docker run reddlinks --user 1000:1000
+```
+
+## Docker compose
+
+`docker compose` can be used to automate the build and run step reddlinks.
+
+By default, the docker-compose file uses the port 8080 (- "8080:8080"), feel free to change it for a more convenient one.
+/!\ Only change the first part of the ports statement (ex: "8081:8080").
+
+To build and run reddlinks using `docker compose`, change directory to `docker/` and run:
+
+```console
+docker compose up
+```
+
+You can also use the `-d` option to run reddlinks as a daemon:
+
+```console
+docker compose up -d
+```
+
+In case of errors, you can use `docker compose logs -f` to see the logs (it is recommended to use it when you start reddlinks manually):
+
+```console
+docker compose up -d && docker compose logs -f
+```

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,30 +1,6 @@
 # Deploy reddlinks with docker
 
-It is strongly recommended to use [docker compose]()
-
-## Docker
-
-The dockerfile in this directory can be used to build a docker container for reddlinks.
-
-By default, the Dockerfile uses the port 8080 (EXPOSE 8080), feel free to change it for a more convenient one.
-
-From reddlinks's root directory:
-
-```console
-docker build -t reddlinks -f docker/Dockerfile .
-```
-
-From the `docker/` directory:
-
-```console
-docker build -t reddlinks -f Dockerfile ../
-```
-
-Run the container:
-
-```console
-docker run reddlinks --user 1000:1000
-```
+It is strongly recommended to use [docker compose](#docker-compose), using only the Dockerfile is broken on purpose.
 
 ## Docker compose
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,44 @@
+---
+version: "3.4"
+
+services:
+  postgresql:
+    image: postgres:latest
+    restart: unless-stopped
+    healthcheck:
+      test: [ "CMD-SHELL", "pg_isready -d $${POSTGRES_DB} -U $${POSTGRES_USER}" ]
+      start_period: 20s
+      interval: 30s
+      retries: 5
+      timeout: 5s
+    volumes:
+      - ../database:/var/lib/postgresql/data
+    environment:
+      POSTGRES_PASSWORD: ${REDDLINKS_PG_PASS:?database password required}
+      POSTGRES_USER: ${REDDLINKS_PG_USER:-rluser}
+      POSTGRES_DB: ${REDDLINKS_PG_DB:-rldb}
+    env_file:
+      - .env
+  reddlinks:
+    build:
+      context: ../
+      dockerfile: docker/Dockerfile
+    restart: unless-stopped
+    environment:
+        POSTGRES_PASSWORD: ${REDDLINKS_PG_PASS:?database password required}
+        POSTGRES_USER: ${REDDLINKS_PG_USER:-rluser}
+        POSTGRES_DB: ${REDDLINKS_PG_DB:-rldb}
+    env_file:
+      - .env
+    depends_on:
+      - postgresql
+    ports:
+      - "8080:8080"
+    user: "1000:1000"
+    volumes:
+      - ../static:/opt/reddlinks/static
+      - .env:/opt/reddlinks/.env
+
+volumes:
+  database:
+    driver: local

--- a/static/add.html
+++ b/static/add.html
@@ -44,7 +44,7 @@
         <button onclick="revealPass()" id="reveal">Reveal Password</button>
     </div>
     {{end}}
-    <p>Will expire on: {{.ExpireAt}}</p>
+    <p>Will expire on: {{.ExpireAt}} UTC</p>
     <div class="div-input">
         <button onclick="copyLink()" id="confirmation" onmouseleave="revertCopy()">Copy Link</button>
     </div>


### PR DESCRIPTION
- Add a Dockerfile and a docker-compose.yml to build and run reddlinks with docker.
- Add workflow to build reddlinks both with go build and with docker.
- Add sample .env for docker (must use it instead of the one in the root when running with docker).
- Display clearly to the user that the expiration time is in UTC.