### PR TITLE
Update http to use the multiplexer

### DIFF
--- a/.github/workflows/gobuild.yml
+++ b/.github/workflows/gobuild.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.21'
+          go-version: '1.22'
           cache: false
       - name: Build the project
         run: |

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.21'
+          go-version: '1.22'
           cache: false
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
@@ -23,4 +23,4 @@ jobs:
           # Require: The version of golangci-lint to use.
           # When `install-mode` is `binary` (default) the value can be v1.2 or v1.2.3 or `latest` to use the latest version.
           # When `install-mode` is `goinstall` the value can be v1.2.3, `latest`, or the hash of a commit.
-          version: v1.55.2
+          version: v1.56.1

--- a/.github/workflows/gotest.yml
+++ b/.github/workflows/gotest.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.21'
+          go-version: '1.22'
           cache: false
       - name: Test the project
         run: |

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21-alpine3.19
+FROM golang:1.22-alpine3.19
 
 RUN apk update && apk add --no-cache build-base git
 

--- a/docker/Dockerfile-ci
+++ b/docker/Dockerfile-ci
@@ -1,4 +1,4 @@
-FROM golang:1.21-alpine3.19
+FROM golang:1.22-alpine3.19
 
 RUN apk update && apk add --no-cache build-base git
 

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@
 
 module github.com/redds-be/reddlinks
 
-go 1.21
+go 1.22
 
 require (
 	github.com/alexedwards/argon2id v1.0.0

--- a/internal/http/handler_err.go
+++ b/internal/http/handler_err.go
@@ -27,13 +27,6 @@ import (
 func HandlerErr(writer http.ResponseWriter, req *http.Request) {
 	log.Printf("%s %s", req.Method, req.URL.Path)
 
-	// If the method is wrong, return with an error
-	if req.Method != http.MethodGet {
-		json.RespondWithError(writer, http.StatusMethodNotAllowed, "Method Not Allowed.")
-
-		return
-	}
-
 	// Respond with a generic error at '/error'
 	json.RespondWithError(writer, http.StatusBadRequest, "Something went wrong.")
 }

--- a/internal/http/handler_front.go
+++ b/internal/http/handler_front.go
@@ -390,7 +390,7 @@ func (conf Configuration) FrontAskForPassword(writer http.ResponseWriter, req *h
 	page := &Page{
 		InstanceTitle:   conf.InstanceName,
 		InstanceURL:     conf.InstanceURL,
-		Short:           utils.TrimFirstRune(req.URL.Path),
+		Short:           req.PathValue("short"),
 		Version:         conf.Version,
 		Token:           Token,
 		TimeOfExecution: time.Now().UTC().Format(time.ANSIC),

--- a/internal/http/handler_readiness.go
+++ b/internal/http/handler_readiness.go
@@ -27,13 +27,6 @@ import (
 func HandlerReadiness(writer http.ResponseWriter, req *http.Request) {
 	log.Printf("%s %s", req.Method, req.URL.Path)
 
-	// Check method
-	if req.Method != http.MethodGet {
-		json.RespondWithError(writer, http.StatusMethodNotAllowed, "Method Not Allowed.")
-
-		return
-	}
-
 	// Define a JSON structure for the status
 	type statusResponse struct {
 		Status string `json:"status"`

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -24,7 +24,6 @@ import (
 	"log"
 	"net/http"
 	"time"
-	"unicode/utf8"
 
 	"github.com/redds-be/reddlinks/internal/database"
 )
@@ -50,13 +49,6 @@ type Parameters struct {
 	Path        string `json:"customPath"`
 	ExpireAfter int    `json:"expireAfter"`
 	Password    string `json:"password"`
-}
-
-// TrimFirstRune removes the first letter of a string (https://go.dev/play/p/ZOZyRORkK82).
-func TrimFirstRune(s string) string {
-	_, i := utf8.DecodeRuneInString(s)
-
-	return s[i:]
 }
 
 // CollectGarbage deletes old expired entries in the database.

--- a/test/api_test.go
+++ b/test/api_test.go
@@ -27,36 +27,20 @@ import (
 )
 
 func (s *APISuite) TestReadiness() {
-	// Test a POST request on a handler that only accepts GET requests
-	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, "/status", nil)
+	// Test a GET request on the readiness handler
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "/status", nil)
 	s.Require().NoError(err)
 	resp := httptest.NewRecorder()
-	HTTP.HandlerReadiness(resp, req)
-	s.Equal(http.StatusMethodNotAllowed, resp.Code)
-	s.Equal("{\"error\":\"405 Method Not Allowed.\"}", resp.Body.String())
-
-	// Test a GET request on the same handler
-	req, err = http.NewRequestWithContext(context.Background(), http.MethodGet, "/status", nil)
-	s.Require().NoError(err)
-	resp = httptest.NewRecorder()
 	HTTP.HandlerReadiness(resp, req)
 	s.Equal(http.StatusOK, resp.Code)
 	s.Equal("{\"status\":\"Alive.\"}", resp.Body.String())
 }
 
 func (s *APISuite) TestErr() {
-	// Test a POST request on a handler that only accepts GET requests
-	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, "/error", nil)
+	// Test a GET request on the generic error handler
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "/error", nil)
 	s.Require().NoError(err)
 	resp := httptest.NewRecorder()
-	HTTP.HandlerErr(resp, req)
-	s.Equal(http.StatusMethodNotAllowed, resp.Code)
-	s.Equal("{\"error\":\"405 Method Not Allowed.\"}", resp.Body.String())
-
-	// Test a GET request on the same handler
-	req, err = http.NewRequestWithContext(context.Background(), http.MethodGet, "/error", nil)
-	s.Require().NoError(err)
-	resp = httptest.NewRecorder()
 	HTTP.HandlerErr(resp, req)
 	s.Equal(http.StatusBadRequest, resp.Code)
 	s.Equal("{\"error\":\"400 Something went wrong.\"}", resp.Body.String())

--- a/test/utils_test.go
+++ b/test/utils_test.go
@@ -31,11 +31,6 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
-func (s *UtilsSuite) TestTrimFirstRune() {
-	// Test if trimFirstRune() does in fact, trim the first rune
-	s.Equal("rimmed", utils.TrimFirstRune("trimmed"))
-}
-
 func (s *UtilsSuite) TestRandomToken() {
 	// Test if randomToken returns something
 	s.NotEmpty(utils.RandomToken())


### PR DESCRIPTION
- Bump to go 1.22.

- Use http's multiplexer as the handler.

- Remove APIHandlerRoot that was acting as a multiplexer/dispatcher for requests, replaced it with mux.HandleFunc using explicit methods.

- Remove TrimFirstRune which was used to get a usable value from the request path which is now replaced by http's PathValue.