### PR TITLE
Remove confirmation to have read the privacy policy

### DIFF
--- a/static/assets/css/main.css
+++ b/static/assets/css/main.css
@@ -43,10 +43,6 @@ p {
     font-size: 16px;
 }
 
-.read {
-    font-size: 10px;
-}
-
 p.nav-text {
     word-spacing: 5px;
 }

--- a/static/index.html
+++ b/static/index.html
@@ -81,7 +81,6 @@
         <div class="div-input">
             <button value="Add" name="add" type="submit">Shorten URL</button>
         </div>
-        <p class="read">By clicking on "Shorten URL", you confirm to have read the <a href="/privacy">Privacy Policy</a>.</p>
     </form>
 </div>
 


### PR DESCRIPTION
Since the privacy policy has nothing to do with terms and conditions, the user does not need to read it to proceed.