### PR TITLE
Use better Dockerfile and docker-compose.yml

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,17 +2,18 @@ FROM golang:1.22-alpine3.19 as build
 
 RUN apk update && apk add --no-cache build-base git
 
-WORKDIR /go/src/app
+WORKDIR /go/src/reddlinks
 COPY . .
 
 RUN go mod download
 RUN CGO_ENABLED=0 make
-RUN mv build/reddlinks /go/bin/app
+RUN mv build/reddlinks /go/bin/reddlinks
 
 FROM gcr.io/distroless/base-debian12
 
-COPY --from=build /go/bin/app /
+COPY --from=build /go/bin/reddlinks /reddlinks
+COPY --from=build /go/src/reddlinks/static /static
 
 EXPOSE 8080
 
-ENTRYPOINT ["/app"]
+ENTRYPOINT ["/reddlinks"]

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,9 +1,6 @@
----
-version: "3.4"
-
 services:
   postgresql:
-    image: postgres:latest
+    image: postgres:16-alpine
     restart: unless-stopped
     healthcheck:
       test: [ "CMD-SHELL", "pg_isready -d $${POSTGRES_DB} -U $${POSTGRES_USER}" ]
@@ -12,7 +9,7 @@ services:
       retries: 5
       timeout: 5s
     volumes:
-      - ../database:/var/lib/postgresql/data
+      - db:/var/lib/postgresql/data
     environment:
       POSTGRES_PASSWORD: ${REDDLINKS_PG_PASS:?database password required}
       POSTGRES_USER: ${REDDLINKS_PG_USER:-rluser}
@@ -36,9 +33,8 @@ services:
       - "8080:8080"
     user: "1000:1000"
     volumes:
-      - ../static:/static
       - .env:/.env
 
 volumes:
-  database:
+  db:
     driver: local


### PR DESCRIPTION
- postgresql now uses a static stable image
- Using local driver correctly for the database
- static/ is now solely inside the reddlinks image

This is the first part of an update related to #28