### PR TITLE
Do javascript the correct way

### DIFF
--- a/internal/http/handler_front.go
+++ b/internal/http/handler_front.go
@@ -59,9 +59,9 @@ type Page struct {
 func RenderTemplate(writer http.ResponseWriter, tmpl string, page *Page) {
 	// Tell that we serve HTML in UTF-8.
 	writer.Header().Set("Content-Type", "text/html; charset=UTF-8")
-	// Tell that all ressources comes from here and that only this site can frame itself
+	// Tell that all resources comes from here and that only this site can frame itself
 	writer.Header().
-		Set("Content-Security-Policy", "default-src 'self'; script-src 'self' 'unsafe-inline';"+
+		Set("Content-Security-Policy", "default-src 'self'; script-src 'self';"+
 			" style-src 'self'; img-src 'self'; connect-src 'self'; frame-src 'self'; font-src 'self'; media-src 'self';"+
 			" object-src 'self'; manifest-src 'self'; worker-src 'self'; form-action 'self'; frame-ancestors 'self'")
 	// Block access to styles and scripts

--- a/static/add.html
+++ b/static/add.html
@@ -24,6 +24,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="assets/css/main.css">
     <link rel="icon" type="image/svg" href="assets/img/reddlinks_logo_t.png">
+    <script type="application/javascript" src="assets/js/add.js"></script>
 </head>
 <body>
 <p class="nav-text"><a href="{{.InstanceURL}}" class="nav-text nav-link">{{.InstanceTitle}}</a>
@@ -36,9 +37,10 @@
     {{if .AddInfo}}
     <p>{{.AddInfo}}</p>
     {{end}}
-    <p>Shortened link: <a href="{{.InstanceURL}}{{.Short}}" target="_blank" id="myInput">{{.ShortenedLink}}</a></p>
+    <p>Shortened link: <a href="{{.InstanceURL}}{{.Short}}" target="_blank" id="short">{{.ShortenedLink}}</a></p>
     <p>Links to: {{.URL}}</p>
     {{if .Password}}
+    <input type="hidden" value="{{.Password}}" id="password">
     <p id="pass">Accessible using password: ********</p>
     <div class="div-input">
         <button onclick="revealPass()" id="reveal">Reveal Password</button>
@@ -46,7 +48,7 @@
     {{end}}
     <p>Will expire on: {{.ExpireAt}} UTC</p>
     <div class="div-input">
-        <button onclick="copyLink()" id="confirmation" onmouseleave="revertCopy()">Copy Link</button>
+        <button onclick="copyLink()" id="copy" onmouseleave="revertCopy()">Copy Link</button>
     </div>
     <form action="/" method="Get">
         <div class="div-input">
@@ -65,28 +67,5 @@
         <a href="https://github.com/redds-be/reddlinks" target="_blank">Source Code</a>.
     </p>
 </div>
-<script>
-    function copyLink() {
-        /* Copy text into clipboard */
-        navigator.clipboard.writeText
-        ("{{.ShortenedLink}}");
-        /* Set the new value for the button */
-        var conf = document.getElementById("confirmation");
-        conf.innerHTML = "Copied Link"
-    }
-    function revertCopy() {
-        /* Reset the value for the button */
-        var conf = document.getElementById("confirmation");
-        conf.innerHTML = "Copy Link"
-    }
-    {{if .Password}}
-    function revealPass() {
-        var pass = document.getElementById("pass")
-        pass.innerHTML = "Accessible using password: {{.Password}}"
-        var rev = document.getElementById("reveal")
-        rev.innerHTML = "Password revealed"
-    }
-    {{end}}
-</script>
 </body>
 </html>

--- a/static/assets/js/add.js
+++ b/static/assets/js/add.js
@@ -1,0 +1,19 @@
+function copyLink() {
+    /* Copy the link into the clipboard */
+    navigator.clipboard.writeText(document.getElementById("short").textContent);
+    /* Tell that the link is copied */
+    document.getElementById("copy").innerHTML = "Copied Link";
+}
+
+function revertCopy() {
+    /* Reset the value for the copy button */
+    document.getElementById("copy").innerHTML = "Copy Link";
+}
+
+function revealPass() {
+    /* Prepare a string to concatenate */
+    let accssibleStr = "Accessible using password:";
+    document.getElementById("pass").innerHTML = accssibleStr.concat(" ", document.getElementById("password").value);
+    /* Tell that the password is revealed */
+    document.getElementById("reveal").innerHTML = "Password revealed";
+}

--- a/test/http/front_test.go
+++ b/test/http/front_test.go
@@ -63,8 +63,8 @@ func (suite frontTestSuite) TestRenderTemplate() {
 	suite.a.Assert(resp.Code, http.StatusOK)
 	suite.a.Assert(resp.Header().Get("X-Content-Type-Options"), "nosniff")
 	suite.a.Assert(resp.Header().Get("Content-Type"), "text/html; charset=UTF-8")
-	suite.a.Assert(resp.Header().Get("Content-Security-Policy"), "default-src 'self'; script-src 'self' "+
-		"'unsafe-inline'; style-src 'self'; img-src 'self'; "+
+	suite.a.Assert(resp.Header().Get("Content-Security-Policy"), "default-src 'self'; script-src 'self'; "+
+		"style-src 'self'; img-src 'self'; "+
 		"connect-src 'self'; frame-src 'self'; font-src 'self'; media-src 'self'; object-src 'self'; manifest-src "+
 		"'self'; worker-src 'self'; form-action 'self'; frame-ancestors 'self'")
 	suite.a.Assert(resp.Body.String(), "<p>InstanceTitle: test</p>\n"+


### PR DESCRIPTION
Put js from static/add.html into static/assets/js/add.js This was done to remove the unsafe-inline from the CSP header.

For some reason, RenderTemplate() doesn't set the correct headers for add.html despite doing it correctly for the other pages.