### PR TITLE
Revert CSP header changes

### DIFF
--- a/internal/http/handler_front.go
+++ b/internal/http/handler_front.go
@@ -28,7 +28,6 @@ import (
 
 	"github.com/alexedwards/argon2id"
 	"github.com/google/uuid"
-
 	"github.com/redds-be/reddlinks/internal/database"
 	"github.com/redds-be/reddlinks/internal/json"
 	"github.com/redds-be/reddlinks/internal/utils"

--- a/internal/http/handler_front.go
+++ b/internal/http/handler_front.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/alexedwards/argon2id"
 	"github.com/google/uuid"
+
 	"github.com/redds-be/reddlinks/internal/database"
 	"github.com/redds-be/reddlinks/internal/json"
 	"github.com/redds-be/reddlinks/internal/utils"
@@ -61,7 +62,7 @@ func RenderTemplate(writer http.ResponseWriter, tmpl string, page *Page, code in
 	writer.Header().Set("Content-Type", "text/html; charset=UTF-8")
 	// Tell that all resources comes from here and that only this site can frame itself
 	writer.Header().
-		Set("Content-Security-Policy", "default-src 'self'; script-src 'self';"+
+		Set("Content-Security-Policy", "default-src 'self'; script-src 'self' 'unsafe-inline';"+
 			" style-src 'self'; img-src 'self'; connect-src 'self'; frame-src 'self'; font-src 'self'; media-src 'self';"+
 			" object-src 'self'; manifest-src 'self'; worker-src 'self'; form-action 'self'; frame-ancestors 'self'")
 	// Block access to styles and scripts

--- a/test/http/front_test.go
+++ b/test/http/front_test.go
@@ -65,7 +65,7 @@ func (suite frontTestSuite) TestRenderTemplate() {
 	suite.a.Assert(resp.Header().Get("Content-Type"), "text/html; charset=UTF-8")
 	suite.a.Assert(
 		resp.Header().Get("Content-Security-Policy"),
-		"default-src 'self'; script-src 'self'; "+
+		"default-src 'self'; script-src 'self' 'unsafe-inline'; "+
 			"style-src 'self'; img-src 'self'; "+
 			"connect-src 'self'; frame-src 'self'; font-src 'self'; media-src 'self'; object-src 'self'; manifest-src "+
 			"'self'; worker-src 'self'; form-action 'self'; frame-ancestors 'self'",


### PR DESCRIPTION
It's sad to do that, however, there isn't any vector for an XSS attack.

[#48](https://github.com/redds-be/reddlinks/issues/48#issue-2340703587) explains why the CSP header has to allow for inline JS.