### PR TITLE
Fix internal version

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,7 +36,7 @@ REDDLINKS_INSTANCE_URL=<http/https>://<sub.domain.tld><:port>/
 # Uncomment the database type you are using (REDDLINKS_DB_TYPE).
 
 # POSTGRES
-########
+##########
 
 ## REDDLINKS_DB_USERNAME: Postgres user username.
 ## REDDLINKS_DB_PASSWORD: The postgres user's very secret and complicated password (can be a hash if postgres is configured for it).
@@ -50,7 +50,7 @@ REDDLINKS_INSTANCE_URL=<http/https>://<sub.domain.tld><:port>/
 #REDDLINKS_DB_STRING=postgres://$REDDLINKS_PG_USERNAME:$REDDLINKS_PG_PASSWORD@$REDDLINKS_PG_HOST/$REDDLINKS_PG_NAME
 
 # SQLITE
-######
+########
 
 ## <database name>: The name of your sqlite database.
 ## For more details including cache or authentication, please check this documentation: <https://github.com/mattn/go-sqlite3#connection-string>

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -11,4 +11,4 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Build Docker image
-        run: docker build -t reddlinks -f docker/Dockerfile .
+        run: docker build --build-arg tag_version=$GITHUB_REF_NAME -t reddlinks -f docker/Dockerfile .

--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,7 @@ prep: fmt mod vet lint test
 
 compile: clean
 	@mkdir -p build/
-	@sed "s/noVersion/$(VERSION)/g" main.go > main.go.alt && mv main.go.alt main.go
-	@go build -o build/
+	@go build -ldflags="-X 'main.Version=$(VERSION)'" -o build/
 
 fmt:
 	golines --max-len=120 --base-formatter=gofumpt -w $(GOFILES)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,13 +1,13 @@
 FROM golang:1.22-alpine3.19 as build
 
-RUN apk update && apk add --no-cache build-base git
+ARG tag_version=noVersion
+ENV tag_version=$tag_version
 
 WORKDIR /go/src/reddlinks
 COPY . .
 
-RUN go mod download
-RUN CGO_ENABLED=0 make
-RUN mv build/reddlinks /go/bin/reddlinks
+RUN go mod download 
+RUN CGO_ENABLED=0 go build -ldflags="-X 'main.Version=$tag_version'" -o /go/bin/reddlinks
 
 FROM gcr.io/distroless/base-debian12
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -12,17 +12,26 @@ By default, the docker-compose file uses the port 8080 (- "8080:8080"), feel fre
 To build and run reddlinks using `docker compose`, change directory to `docker/` and run:
 
 ```console
+docker compose build --build-arg tag_version=$(git describe --tags)
 docker compose up
 ```
+
+> Note: You could only use `docker compose up` if you don't want to display the version information.
 
 You can also use the `-d` option to run reddlinks as a daemon:
 
 ```console
+docker compose build --build-arg tag_version=$(git describe --tags)
 docker compose up -d
 ```
 
-In case of errors, you can use `docker compose logs -f` to see the logs (it is recommended to use it when you start reddlinks manually):
+> Note: You could only use `docker compose up -d` if you don't want to display the version information.
+
+In case of errors, you can use `docker compose logs -f` to see the logs (it is recommended to use it when you start reddlinks for the first time to see if everything works):
 
 ```console
+docker compose build --build-arg tag_version=$(git describe --tags)
 docker compose up -d && docker compose logs -f
 ```
+
+> Note: You could only use `docker compose up -d && docker compose logs -f` if you don't want to display the version information.

--- a/main.go
+++ b/main.go
@@ -29,6 +29,9 @@ import (
 	"github.com/redds-be/reddlinks/internal/utils"
 )
 
+// Variable for the version set by ldflags.
+var Version string //nolint:gochecknoglobals
+
 //go:embed static
 var embeddedStatic embed.FS
 
@@ -69,7 +72,7 @@ func main() {
 		DefaultExpiryTime:      envVars.DefaultExpiryTime,
 		ContactEmail:           envVars.ContactEmail,
 		Static:                 embeddedStatic,
-		Version:                "noVersion",
+		Version:                Version,
 	}
 
 	// Start periodic jobs

--- a/main.go
+++ b/main.go
@@ -29,7 +29,7 @@ import (
 	"github.com/redds-be/reddlinks/internal/utils"
 )
 
-// Variable for the version set by ldflags.
+// Version is a variable for the version set by ldflags.
 var Version string //nolint:gochecknoglobals
 
 //go:embed static


### PR DESCRIPTION
Use ldflags instead of sed for internal versioning.

This should have been done long ago, I'm just lazy.