### PR TITLE
Add systemd service

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -37,10 +37,18 @@ nfpms:
       A simple link shortener written in Go.
     license: GPL-3.0
     formats:
-      - apk
       - deb
       - rpm
       - archlinux
+    scripts:
+      preinstall: "scripts/preinstall.sh"
+      postinstall: "scripts/postinstall.sh"
+      postremove: "scripts/postremove.sh"
+    contents:
+      - src: systemd/reddlinks.service
+        dst: /etc/systemd/system/reddlinks.service
+      - src: .env.example
+        dst: /opt/reddlinks/.env
 
 dockers:
   - image_templates:

--- a/scripts/postinstall.sh
+++ b/scripts/postinstall.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+chmod 0644 /etc/systemd/system/reddlinks.service
+systemctl daemon-reload
+chmod 0660 /opt/reddlinks/.env
+chown -R reddlinks:reddlinks /opt/reddlinks

--- a/scripts/postremove.sh
+++ b/scripts/postremove.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+systemctl stop --now reddlinks.service
+systemctl daemon-reload
+userdel reddlinks

--- a/scripts/preinstall.sh
+++ b/scripts/preinstall.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+useradd -M -s /usr/bin/nologin reddlinks

--- a/systemd/reddlinks.service
+++ b/systemd/reddlinks.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=A simple link shortener
+After=network.target
+
+[Service]
+Type=simple
+WorkingDirectory=/opt/reddlinks
+EnvironmentFile=/opt/reddlinks/.env
+ExecStart=/usr/bin/reddlinks
+User=reddlinks
+Group=reddlinks
+Restart=always
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Added a systemd service which runs /usr/bin/reddlinks in /opt/reddlinks as the user reddlinks and loads /opt/reddlinks/.env.

Added scripts/preinstall.sh which creates the reddlinks user.

Added scripts/postinstall.sh which sets permissions for the service and the working directory.

Added postremove.sh which stops reddlinks and deletes the reddlinks user.