### PR TITLE
Make REDDLINKS_DB_STRING not mendatory for postgres

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,16 +37,19 @@ REDDLINKS_INSTANCE_URL=<http/https>://<sub.domain.tld>:<port>
 # POSTGRES
 ##########
 
+## If you are using a socket, please configure REDDLINKS_DB_STRING
 ## REDDLINKS_DB_USERNAME: Postgres user username.
 ## REDDLINKS_DB_PASSWORD: The postgres user's very secret and complicated password (can be a hash if postgres is configured for it).
-## REDDLINKS_DB_HOST: The host on which postgres runs on can be 'localhost' or a unix socket if running locally.
+## REDDLINKS_DB_HOST: The host on which postgres runs on.
+## REDDLINKS_DB_PORT: The port on which postgres runs on.
 ## REDDLINKS_DB_NAME: The name of your postgres database.
 #REDDLINKS_DB_TYPE=postgres
 #REDDLINKS_DB_USERNAME=reddlinksuser
 #REDDLINKS_DB_PASSWORD=121f2ca6c7572f8a0ef899c19ac0b2736c158dfc0f288bfe4e28
-#REDDLINKS_DB_HOST=localhost:5432
+#REDDLINKS_DB_HOST=localhost
+#REDDLINKS_DB_PORT=5432
 #REDDLINKS_DB_NAME=reddlinks
-#REDDLINKS_DB_STRING=postgres://$REDDLINKS_PG_USERNAME:$REDDLINKS_PG_PASSWORD@$REDDLINKS_PG_HOST/$REDDLINKS_PG_NAME
+#REDDLINKS_DB_STRING=postgres://$REDDLINKS_DB_USERNAME:$REDDLINKS_DB_PASSWORD@$REDDLINKS_DB_HOST:$REDDLINKS_DB_PORT/$REDDLINKS_DB_NAME
 
 # SQLITE
 ########

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -33,17 +33,19 @@ REDDLINKS_INSTANCE_URL=<http/https>://<sub.domain.tld><:port>
 # DATABASE CONFIG #
 ###################
 
-## <postgres username>: Postgres user username.
-## <postgres user password>: The postgres user's very secret and complicated password (can be a hash if postgres is configured for it).
-## <postgres host>: The host on which postgres runs on can be 'localhost' or a unix socket if running locally.
-## <postgres port>: The port of the postgres server, by default, the port is 5432.
-## <postgres database>: The name of your postgres database.
-## For more details or examples, please check this documentation: <https://www.postgresql.org/docs/14/libpq-connect.html#id-1.7.3.8.3.6>
-REDDLINKS_PG_USER=rluser
-REDDLINKS_PG_PASS=
-REDDLINKS_PG_DB=rldb
-REDDLINKS_DB_TYPE=postgres
-REDDLINKS_DB_STRING=postgres://$REDDLINKS_PG_USER:$REDDLINKS_PG_PASS@postgresql:5432/$REDDLINKS_PG_DB?sslmode=disable
+## If you are using the default docker-compose.yml file, only REDDLINKS_DB_PASSWORD is needed here, although modifying the others vars will overwrite their default value set in docker-compose.yml.
+## REDDLINKS_DB_USERNAME: Postgres user username.
+## REDDLINKS_DB_PASSWORD: The postgres user's very secret and complicated password (can be a hash if postgres is configured for it).
+## REDDLINKS_DB_HOST: The host on which postgres runs on.
+## REDDLINKS_DB_PORT: The port on which postgres runs on.
+## REDDLINKS_DB_NAME: The name of your postgres database.
+#REDDLINKS_DB_USERNAME=rluser
+REDDLINKS_DB_PASSWORD=
+#REDDLINKS_DB_NAME=rldb
+#REDDLINKS_DB_HOST=localhost
+#REDDLINKS_DB_PORT=5432
+#REDDLINKS_DB_TYPE=postgres
+#REDDLINKS_DB_STRING=postgres://$REDDLINKS_PG_USER:$REDDLINKS_PG_PASS@postgresql:5432/$REDDLINKS_PG_DB?sslmode=disable
 
 ## Time between database cleanup in minutes, 1 for 1 minute, 60 for 1 hour, 120 for 2 hours, ...
 REDDLINKS_TIME_BETWEEN_DB_CLEANUPS=<time in minutes>

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /go/src/reddlinks
 COPY . .
 
 RUN go mod download
-RUN CGO_ENABLED=0 go build -ldflags="-X 'main.Version=$tag_version'" -o /go/bin/reddlinks
+RUN CGO_ENABLED=0 go build -ldflags="-X 'main.version=$tag_version'" -o /go/bin/reddlinks
 
 FROM gcr.io/distroless/base-debian12
 

--- a/docker/docker-compose.build.yml
+++ b/docker/docker-compose.build.yml
@@ -11,9 +11,9 @@ services:
     volumes:
       - db:/var/lib/postgresql/data
     environment:
-      POSTGRES_PASSWORD: ${REDDLINKS_PG_PASS:?database password required}
-      POSTGRES_USER: ${REDDLINKS_PG_USER:-rluser}
-      POSTGRES_DB: ${REDDLINKS_PG_DB:-rldb}
+      POSTGRES_PASSWORD: ${REDDLINKS_DB_PASSWORD:?database password required}
+      POSTGRES_USER: ${REDDLINKS_DB_USERNAME:-rluser}
+      POSTGRES_DB: ${REDDLINKS_DB_NAME:-rldb}
     env_file:
       - .env
   reddlinks:
@@ -21,6 +21,10 @@ services:
       context: ../
       dockerfile: docker/Dockerfile
     restart: unless-stopped
+    environment:
+      REDDLINKS_DB_HOST: ${REDDLINKS_DB_HOST:-postgresql}
+      REDDLINKS_DB_PORT: ${REDDLINKS_DB_PORT:-5432}
+      REDDLINKS_DB_TYPE: ${REDDLINKS_DB_TYPE:-postgres}
     env_file:
       - .env
     depends_on:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -11,14 +11,18 @@ services:
     volumes:
       - db:/var/lib/postgresql/data
     environment:
-      POSTGRES_PASSWORD: ${REDDLINKS_PG_PASS:?database password required}
-      POSTGRES_USER: ${REDDLINKS_PG_USER:-rluser}
-      POSTGRES_DB: ${REDDLINKS_PG_DB:-rldb}
+      POSTGRES_PASSWORD: ${REDDLINKS_DB_PASSWORD:?database password required}
+      POSTGRES_USER: ${REDDLINKS_DB_USERNAME:-rluser}
+      POSTGRES_DB: ${REDDLINKS_DB_NAME:-rldb}
     env_file:
       - .env
   reddlinks:
     image: ghcr.io/redds-be/reddlinks:latest
     restart: unless-stopped
+    environment:
+      - REDDLINKS_DB_HOST: ${REDDLINKS_DB_HOST:-postgresql}
+      - REDDLINKS_DB_PORT: ${REDDLINKS_DB_PORT:-5432}
+      - REDDLINKS_DB_TYPE: ${REDDLINKS_DB_TYPE:-postgres}
     env_file:
       - .env
     depends_on:

--- a/internal/env/get_env.go
+++ b/internal/env/get_env.go
@@ -47,6 +47,11 @@ type Env struct {
 	InstanceName           string
 	InstanceURL            string
 	DBType                 string
+	DBUser                 string
+	DBPass                 string
+	DBHost                 string
+	DBPort                 string
+	DBName                 string
 	DBURL                  string
 	ContactEmail           string
 	TimeBetweenCleanups    int
@@ -61,7 +66,6 @@ type Env struct {
 // InstanceName is checked for emptyness,
 // InstanceURL is checked with a regexp for having http/https and trailing '/',
 // DBType is checked for being either 'postgres' or 'sqlite' with a regexp,
-// DBURL is checked for emptyness,
 // TimeBetweenCleanups is checked for being positive,
 // DefaultLength is checked for being positive and not being superior to DefaultMaxLength,
 // DefaultMaxCustomLength is checked for being positive and not being superior to DefaultMaxLength,
@@ -90,11 +94,6 @@ func (env Env) EnvCheck() error { //nolint:funlen,cyclop
 	}
 	if env.DBType == "" || !dbTypeMatch {
 		return fmt.Errorf("the database type %w", ErrInvalidOrUnsupported)
-	}
-
-	// Check if the database access string is empty or not.
-	if env.DBURL == "" {
-		return fmt.Errorf("the database access string %w", ErrEmpty)
 	}
 
 	// Check the time between cleanups, can be any time really, so only checking if it's 0 or less
@@ -234,8 +233,35 @@ func GetEnv(envFile string) Env { //nolint:funlen,cyclop
 
 	// Read the database URL
 	dbURL := os.Getenv("REDDLINKS_DB_STRING")
-	if dbURL == "" {
-		log.Fatal("reddlinks could not find a value for REDDLINKS_DB_STRING env variable")
+
+	// Read the database username
+	dbUser := os.Getenv("REDDLINKS_DB_USERNAME")
+	if dbUser == "" && dbURL == "" {
+		log.Fatal("reddlinks could not find a value for REDDLINKS_DB_USERNAME env variable")
+	}
+
+	// Read the database password
+	dbPass := os.Getenv("REDDLINKS_DB_PASSWORD")
+	if dbPass == "" && dbURL == "" {
+		log.Fatal("reddlinks could not find a value for REDDLINKS_DB_PASSWORD env variable")
+	}
+
+	// Read the database host
+	dbHost := os.Getenv("REDDLINKS_DB_HOST")
+	if dbHost == "" && dbURL == "" {
+		log.Fatal("reddlinks could not find a value for REDDLINKS_DB_HOST env variable")
+	}
+
+	// Read the database port
+	dbPort := os.Getenv("REDDLINKS_DB_PORT")
+	if dbPort == "" && dbURL == "" {
+		log.Fatal("reddlinks could not find a value for REDDLINKS_DB_PORT env variable")
+	}
+
+	// Read the database name
+	dbName := os.Getenv("REDDLINKS_DB_NAME")
+	if dbName == "" && dbURL == "" {
+		log.Fatal("reddlinks could not find a value for REDDLINKS_DB_NAME env variable")
 	}
 
 	// Read the time between cleanup and convert it to an int
@@ -259,6 +285,11 @@ func GetEnv(envFile string) Env { //nolint:funlen,cyclop
 		InstanceName:           instanceName,
 		InstanceURL:            instanceURL,
 		DBType:                 dbType,
+		DBUser:                 dbUser,
+		DBPass:                 dbPass,
+		DBHost:                 dbHost,
+		DBPort:                 dbPort,
+		DBName:                 dbName,
 		DBURL:                  dbURL,
 		ContactEmail:           contactEmail,
 		TimeBetweenCleanups:    timeBetweenCleanups,

--- a/main.go
+++ b/main.go
@@ -53,7 +53,15 @@ func main() { //nolint:funlen
 	envVars := env.GetEnv(envFile)
 
 	// Connect to the database
-	dbase, err := database.DBConnect(envVars.DBType, envVars.DBURL)
+	dbase, err := database.DBConnect(
+		envVars.DBType,
+		envVars.DBURL,
+		envVars.DBUser,
+		envVars.DBPass,
+		envVars.DBHost,
+		envVars.DBPort,
+		envVars.DBName,
+	)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/test/database/db_test.go
+++ b/test/database/db_test.go
@@ -30,11 +30,27 @@ func (suite dbTestSuite) TestDB() { //nolint:funlen
 	// Testing the creation of the database
 	testEnv := env.GetEnv("../.env.test")
 	testEnv.DBURL = "db_test.db"
-	dataBase, err := database.DBConnect(testEnv.DBType, testEnv.DBURL)
+	dataBase, err := database.DBConnect(
+		testEnv.DBType,
+		testEnv.DBURL,
+		testEnv.DBUser,
+		testEnv.DBPass,
+		testEnv.DBHost,
+		testEnv.DBPort,
+		testEnv.DBName,
+	)
 	suite.a.AssertNoErr(err)
 
 	// Testing the creation of the database with a random driver
-	_, err = database.DBConnect("legitdriver", testEnv.DBURL)
+	_, err = database.DBConnect(
+		"legitdriver",
+		testEnv.DBURL,
+		testEnv.DBUser,
+		testEnv.DBPass,
+		testEnv.DBHost,
+		testEnv.DBPort,
+		testEnv.DBName,
+	)
 	suite.a.AssertErr(err)
 
 	// Testing the creation of the links table

--- a/test/env/env_test.go
+++ b/test/env/env_test.go
@@ -116,14 +116,6 @@ func (suite envTestSuite) TestAreErrorsCorrect() { //nolint:funlen
 	// Reset the database type
 	envToCheck.DBType = "postgres"
 
-	// Test if the database string errors are correct
-	envToCheck.DBURL = ""
-	err = envToCheck.EnvCheck()
-	suite.a.AssertErrIs(err, env.ErrEmpty)
-
-	// Reset the database string
-	envToCheck.DBURL = "postgres://user:pass@localhost:5432/db"
-
 	// Test if the time between cleanups errors are correct
 	envToCheck.TimeBetweenCleanups = 0
 	err = envToCheck.EnvCheck()

--- a/test/http/api_test.go
+++ b/test/http/api_test.go
@@ -56,7 +56,15 @@ func (suite apiTestSuite) TestMainAPIHandlers() { //nolint:funlen,maintidx
 	}
 
 	// Prep everything
-	dataBase, err := database.DBConnect(testEnv.DBType, testEnv.DBURL)
+	dataBase, err := database.DBConnect(
+		testEnv.DBType,
+		testEnv.DBURL,
+		testEnv.DBUser,
+		testEnv.DBPass,
+		testEnv.DBHost,
+		testEnv.DBPort,
+		testEnv.DBName,
+	)
 	suite.a.AssertNoErrf(err)
 
 	err = database.CreateLinksTable(dataBase, testEnv.DefaultMaxLength)

--- a/test/http/front_test.go
+++ b/test/http/front_test.go
@@ -103,7 +103,15 @@ func (suite frontTestSuite) TestMainFrontHandlers() { //nolint:funlen
 	}
 
 	// Prep everything
-	dataBase, err := database.DBConnect(testEnv.DBType, testEnv.DBURL)
+	dataBase, err := database.DBConnect(
+		testEnv.DBType,
+		testEnv.DBURL,
+		testEnv.DBUser,
+		testEnv.DBPass,
+		testEnv.DBHost,
+		testEnv.DBPort,
+		testEnv.DBName,
+	)
 	suite.a.AssertNoErr(err)
 
 	err = database.CreateLinksTable(dataBase, testEnv.DefaultMaxLength)

--- a/test/links/links_test.go
+++ b/test/links/links_test.go
@@ -25,7 +25,15 @@ func (suite linksTestSuite) TestCreateLink() { //nolint:funlen
 	}
 
 	// Prep everything
-	dataBase, err := database.DBConnect(testEnv.DBType, testEnv.DBURL)
+	dataBase, err := database.DBConnect(
+		testEnv.DBType,
+		testEnv.DBURL,
+		testEnv.DBUser,
+		testEnv.DBPass,
+		testEnv.DBHost,
+		testEnv.DBPort,
+		testEnv.DBName,
+	)
 	suite.a.AssertNoErr(err)
 
 	err = database.CreateLinksTable(dataBase, testEnv.DefaultMaxLength)

--- a/test/utils/utils_test.go
+++ b/test/utils/utils_test.go
@@ -36,7 +36,15 @@ func (suite utilsTestSuite) TestCollectGarbage() {
 	// Prepare the database needed for garbage collection
 	testEnv := env.GetEnv("../.env.test")
 	testEnv.DBURL = "utils_test.db"
-	dataBase, err := database.DBConnect(testEnv.DBType, testEnv.DBURL)
+	dataBase, err := database.DBConnect(
+		testEnv.DBType,
+		testEnv.DBURL,
+		testEnv.DBUser,
+		testEnv.DBPass,
+		testEnv.DBHost,
+		testEnv.DBPort,
+		testEnv.DBName,
+	)
 	suite.a.AssertNoErr(err)
 
 	err = database.CreateLinksTable(dataBase, testEnv.DefaultMaxLength)


### PR DESCRIPTION
Although you can still use it, you will only require REDDLINKS_DB_USERNAME, REDDLINKS_DB_PASSWORD, REDDLINKS_DB_NAME, REDDLINKS_DB_HOST and REDDLINKS_DB_PORT.