### PR TITLE
Allow a link to never expire by default

### DIFF
--- a/internal/env/errors.go
+++ b/internal/env/errors.go
@@ -26,6 +26,7 @@ import "errors"
 // ErrInvalid defines an error for variables where a value is invalid,
 // ErrInvalidOrUnsupported defines an error for variables where a value is either invalid or unsupported,
 // ErrNullOrNegative defines an error for variables where a value is either null or negative,
+// ErrNegative defines an error for variables where a value is negative,
 // ErrSuperior defines an error for variables where a value can't be superior to another one,
 // ErrInferior defines an error for variables where a value can't be inferior to another one.
 var (
@@ -35,6 +36,7 @@ var (
 	ErrInvalid              = errors.New("is invalid")
 	ErrInvalidOrUnsupported = errors.New("is invalid or unsupported")
 	ErrNullOrNegative       = errors.New("can't be null or negative")
+	ErrNegative             = errors.New("can't be negative")
 	ErrSuperior             = errors.New("can't be superior to")
 	ErrInferior             = errors.New("can't be inferior to")
 )

--- a/internal/env/get_env.go
+++ b/internal/env/get_env.go
@@ -71,7 +71,7 @@ type Env struct {
 // DefaultMaxCustomLength is checked for being positive and not being superior to DefaultMaxLength,
 // DefaultMaxLength is checked for being positive,
 // being superior or equal to DefaultLength and DefaultMaxCustomLength and for being inferior to 8000
-// DefaultExpiryTime is checked for being positive.
+// DefaultExpiryTime is checked for being null or positive.
 func (env Env) EnvCheck() error { //nolint:funlen,cyclop
 	// Check if the instance name isn't null
 	if env.InstanceName == "" {
@@ -136,8 +136,8 @@ func (env Env) EnvCheck() error { //nolint:funlen,cyclop
 	}
 
 	// Check the default expiry time
-	if env.DefaultExpiryTime <= 0 {
-		return fmt.Errorf("the default expiry time %w", ErrNullOrNegative)
+	if env.DefaultExpiryTime < 0 {
+		return fmt.Errorf("the default expiry time %w", ErrNegative)
 	}
 
 	// No errors, since everything is fine

--- a/internal/http/handler_api.go
+++ b/internal/http/handler_api.go
@@ -179,7 +179,12 @@ func (conf Configuration) APICreateLink( //nolint:funlen
 		ReplaceAllString(fmt.Sprintf("%s%s", conf.InstanceURL, link.Short), "")
 
 	// Format the expiration date that will be displayed to the user
-	expireAt := link.ExpireAt.Format(time.RFC822)
+	var expireAt string
+	if params.ExpireDate == "" && params.ExpireAfter == "" && conf.DefaultExpiryTime == 0 {
+		expireAt = "Never"
+	} else {
+		expireAt = link.ExpireAt.Format(time.RFC822)
+	}
 
 	// If there's a password return links.PassJSONLink, if there's none return links.SimpleJSONLink
 	if params.Password != "" {

--- a/internal/http/handler_front.go
+++ b/internal/http/handler_front.go
@@ -120,8 +120,14 @@ func (conf Configuration) FrontErrorPage(
 //
 // An expiry date is created by adding DefaultExpiryTime to now, this date will be used as the default expiry date in the form.
 func (conf Configuration) FrontHandlerMainPage(writer http.ResponseWriter, _ *http.Request) {
-	// Convert default expiry time into date
-	defaultExpiryDate := time.Now().UTC().Add(time.Minute * time.Duration(conf.DefaultExpiryTime))
+	var defaultExpiryDate string
+	if conf.DefaultExpiryTime != 0 {
+		// Convert default expiry time into date
+		defaultExpiryDate = time.Now().
+			UTC().
+			Add(time.Minute * time.Duration(conf.DefaultExpiryTime)).
+			Format("2006-01-02T15:04")
+	}
 
 	// Set what is going to be displayed on the main page
 	page := &Page{
@@ -132,7 +138,7 @@ func (conf Configuration) FrontHandlerMainPage(writer http.ResponseWriter, _ *ht
 		DefaultShortLength:     conf.DefaultShortLength,
 		DefaultMaxShortLength:  conf.DefaultMaxShortLength,
 		DefaultMaxCustomLength: conf.DefaultMaxCustomLength,
-		DefaultExpiryDate:      defaultExpiryDate.Format("2006-01-02T15:04"),
+		DefaultExpiryDate:      defaultExpiryDate,
 		Version:                conf.Version,
 	}
 
@@ -222,7 +228,12 @@ func (conf Configuration) FrontHandlerAdd( //nolint:funlen
 	}
 
 	// Format the expiration date that will be displayed to the user
-	expireAt := link.ExpireAt.Format(time.RFC822)
+	var expireAt string
+	if params.ExpireDate == "" && params.ExpireAfter == "" && conf.DefaultExpiryTime == 0 {
+		expireAt = "Never"
+	} else {
+		expireAt = link.ExpireAt.Format(time.RFC822)
+	}
 
 	// Set what is going to be displayed on the add page
 	page := &Page{

--- a/main.go
+++ b/main.go
@@ -75,7 +75,7 @@ func main() { //nolint:funlen
 	}(dbase)
 
 	// Create the links table if it doesn't exist
-	err = database.CreateLinksTable(dbase, envVars.DefaultMaxLength)
+	err = database.CreateLinksTable(dbase, envVars.DBType, envVars.DefaultMaxLength)
 	if err != nil {
 		log.Panic(err)
 	}

--- a/test/database/db_test.go
+++ b/test/database/db_test.go
@@ -54,7 +54,7 @@ func (suite dbTestSuite) TestDB() { //nolint:funlen
 	suite.a.AssertErr(err)
 
 	// Testing the creation of the links table
-	err = database.CreateLinksTable(dataBase, testEnv.DefaultMaxLength)
+	err = database.CreateLinksTable(dataBase, testEnv.DBType, testEnv.DefaultMaxLength)
 	suite.a.AssertNoErr(err)
 
 	// Testing the creation of a link entry

--- a/test/env/env_test.go
+++ b/test/env/env_test.go
@@ -180,14 +180,10 @@ func (suite envTestSuite) TestAreErrorsCorrect() { //nolint:funlen
 	// Reset the default max length
 	envToCheck.DefaultMaxCustomLength = 255
 
-	// Test if the default expiry time are correct
-	envToCheck.DefaultExpiryTime = 0
-	err = envToCheck.EnvCheck()
-	suite.a.AssertErrIs(err, env.ErrNullOrNegative)
-
+	// Test if the default expiry time errors are correct
 	envToCheck.DefaultExpiryTime = -17
 	err = envToCheck.EnvCheck()
-	suite.a.AssertErrIs(err, env.ErrNullOrNegative)
+	suite.a.AssertErrIs(err, env.ErrNegative)
 }
 
 // Test suite structure.

--- a/test/http/api_test.go
+++ b/test/http/api_test.go
@@ -67,7 +67,7 @@ func (suite apiTestSuite) TestMainAPIHandlers() { //nolint:funlen,maintidx
 	)
 	suite.a.AssertNoErrf(err)
 
-	err = database.CreateLinksTable(dataBase, testEnv.DefaultMaxLength)
+	err = database.CreateLinksTable(dataBase, testEnv.DBType, testEnv.DefaultMaxLength)
 	suite.a.AssertNoErrf(err)
 
 	conf := &utils.Configuration{
@@ -159,7 +159,10 @@ func (suite apiTestSuite) TestMainAPIHandlers() { //nolint:funlen,maintidx
 		returnedLink.ExpireAt,
 		time.Now().UTC().Add(time.Duration(conf.DefaultExpiryTime)*time.Minute).Format(time.RFC822),
 	)
-	suite.a.Assert(len(strings.ReplaceAll(returnedLink.ShortenedLink, instanceURLWithoutProto, "")), params.Length)
+	suite.a.Assert(
+		len(strings.ReplaceAll(returnedLink.ShortenedLink, instanceURLWithoutProto, "")),
+		params.Length,
+	)
 
 	// Test link redirection with custom length for random short
 	req = httptest.NewRequest(
@@ -200,8 +203,14 @@ func (suite apiTestSuite) TestMainAPIHandlers() { //nolint:funlen,maintidx
 		returnedLink.ExpireAt,
 		time.Now().UTC().Add(time.Duration(conf.DefaultExpiryTime)*time.Minute).Format(time.RFC822),
 	)
-	suite.a.Assert(len(strings.ReplaceAll(returnedLink.ShortenedLink, instanceURLWithoutProto, "")), len(params.Path))
-	suite.a.Assert(strings.ReplaceAll(returnedLink.ShortenedLink, instanceURLWithoutProto, ""), params.Path)
+	suite.a.Assert(
+		len(strings.ReplaceAll(returnedLink.ShortenedLink, instanceURLWithoutProto, "")),
+		len(params.Path),
+	)
+	suite.a.Assert(
+		strings.ReplaceAll(returnedLink.ShortenedLink, instanceURLWithoutProto, ""),
+		params.Path,
+	)
 
 	// Test link redirection with a custom short
 	req = httptest.NewRequest(

--- a/test/http/front_test.go
+++ b/test/http/front_test.go
@@ -114,7 +114,7 @@ func (suite frontTestSuite) TestMainFrontHandlers() { //nolint:funlen
 	)
 	suite.a.AssertNoErr(err)
 
-	err = database.CreateLinksTable(dataBase, testEnv.DefaultMaxLength)
+	err = database.CreateLinksTable(dataBase, testEnv.DBType, testEnv.DefaultMaxLength)
 	suite.a.AssertNoErr(err)
 
 	conf := &utils.Configuration{

--- a/test/links/links_test.go
+++ b/test/links/links_test.go
@@ -36,7 +36,7 @@ func (suite linksTestSuite) TestCreateLink() { //nolint:funlen
 	)
 	suite.a.AssertNoErr(err)
 
-	err = database.CreateLinksTable(dataBase, testEnv.DefaultMaxLength)
+	err = database.CreateLinksTable(dataBase, testEnv.DBType, testEnv.DefaultMaxLength)
 	suite.a.AssertNoErr(err)
 
 	conf := &utils.Configuration{

--- a/test/utils/utils_test.go
+++ b/test/utils/utils_test.go
@@ -47,7 +47,7 @@ func (suite utilsTestSuite) TestCollectGarbage() {
 	)
 	suite.a.AssertNoErr(err)
 
-	err = database.CreateLinksTable(dataBase, testEnv.DefaultMaxLength)
+	err = database.CreateLinksTable(dataBase, testEnv.DBType, testEnv.DefaultMaxLength)
 	suite.a.AssertNoErr(err)
 	err = database.CreateLink(
 		dataBase,
@@ -81,7 +81,12 @@ func (suite utilsTestSuite) TestDecodeJSON() {
 	suite.a.AssertNoErr(err)
 
 	// Mock request
-	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, "/", bytes.NewBuffer(enc))
+	req, err := http.NewRequestWithContext(
+		context.Background(),
+		http.MethodPost,
+		"/",
+		bytes.NewBuffer(enc),
+	)
 	suite.a.AssertNoErr(err)
 
 	// Test the decodeJSON() function and compare its return value to the expected values
@@ -98,7 +103,8 @@ func (suite utilsTestSuite) TestGenStr() {
 
 	suite.a.Assert(len(randStr), testLength)
 
-	if !strings.Contains(randStr, "A") && !strings.Contains(randStr, "B") && !strings.Contains(randStr, "C") {
+	if !strings.Contains(randStr, "A") && !strings.Contains(randStr, "B") &&
+		!strings.Contains(randStr, "C") {
 		suite.t.Errorf("%s does not contain either A, B, or C.", randStr)
 	}
 }


### PR DESCRIPTION
A value of 0 for REDDLINKS_DEF_EXPIRY_TIME is now permitted, allowing for a link to have no expiration by default.

Add the updateLinksTable() function, it will handle database breaking changes and is also used to modify the max lenght of short on the database side.