### PR TITLE
Add event listeners to avoid inline js

### DIFF
--- a/internal/http/handler_front.go
+++ b/internal/http/handler_front.go
@@ -79,7 +79,7 @@ func RenderTemplate(writer http.ResponseWriter, tmpl string, page *Page, code in
 	writer.Header().Set("Content-Type", "text/html; charset=UTF-8")
 	// Tell that all resources comes from here and that only this site can frame itself
 	writer.Header().
-		Set("Content-Security-Policy", "default-src 'self'; script-src 'self' 'unsafe-inline';"+
+		Set("Content-Security-Policy", "default-src 'self'; script-src 'self';"+
 			" style-src 'self'; img-src 'self'; connect-src 'self'; frame-src 'self'; font-src 'self'; media-src 'self';"+
 			" object-src 'self'; manifest-src 'self'; worker-src 'self'; form-action 'self'; frame-ancestors 'self'")
 	// Block access to styles and scripts

--- a/static/add.tmpl
+++ b/static/add.tmpl
@@ -18,7 +18,6 @@
 
 {{template "head.tmpl" .}}
 {{template "nav.tmpl" .}}
-<script type="application/javascript" src="assets/js/add.js"></script>
 <div class="main">
     {{if .AddInfo}}
     <p>{{.AddInfo}}</p>
@@ -29,12 +28,12 @@
     <input type="hidden" value="{{.Password}}" id="password">
     <p id="pass">Accessible using password: ********</p>
     <div class="div-input">
-        <button onclick="revealPass()" id="reveal">Reveal Password</button>
+        <button id="reveal">Reveal Password</button>
     </div>
     {{end}}
     <p>Will expire on: {{.ExpireAt}}</p>
     <div class="div-input">
-        <button onclick="copyLink()" id="copy" onmouseleave="revertCopy()">Copy Link</button>
+        <button id="copy">Copy Link</button>
     </div>
     <form action="/" method="Get">
         <div class="div-input">
@@ -42,4 +41,5 @@
         </div>
     </form>
 </div>
+<script type="application/javascript" src="assets/js/add.js"></script>
 {{template "footer.tmpl" .}}

--- a/static/assets/js/add.js
+++ b/static/assets/js/add.js
@@ -17,3 +17,7 @@ function revealPass() {
     /* Tell that the password is revealed */
     document.getElementById("reveal").innerHTML = "Password revealed";
 }
+
+document.getElementById("copy").addEventListener("click", copyLink); 
+document.getElementById("copy").addEventListener("mouseout", revertCopy); 
+document.getElementById("reveal").addEventListener("click", revealPass); 

--- a/test/http/front_test.go
+++ b/test/http/front_test.go
@@ -64,7 +64,7 @@ func (suite frontTestSuite) TestRenderTemplate() {
 	suite.a.Assert(resp.Header().Get("Content-Type"), "text/html; charset=UTF-8")
 	suite.a.Assert(
 		resp.Header().Get("Content-Security-Policy"),
-		"default-src 'self'; script-src 'self' 'unsafe-inline'; "+
+		"default-src 'self'; script-src 'self'; "+
 			"style-src 'self'; img-src 'self'; "+
 			"connect-src 'self'; frame-src 'self'; font-src 'self'; media-src 'self'; object-src 'self'; manifest-src "+
 			"'self'; worker-src 'self'; form-action 'self'; frame-ancestors 'self'",


### PR DESCRIPTION
The inline js was removed from static/add.tmpl and event listeners were added to static/assets/js/add.js.

Removed 'unsafe-inline' from the CSP header.

fixes #48