### PR TITLE
Use template.ParseGlob instead of specifying each template to template.ParseFiles

### DIFF
--- a/main.go
+++ b/main.go
@@ -109,11 +109,7 @@ func main() { //nolint:funlen
 
 	// Parse html templates
 	if _, err := os.Stat("./custom_static"); !os.IsNotExist(err) {
-		http.Templates = template.Must(
-			template.ParseFiles("./custom_static/index.tmpl", "./custom_static/add.tmpl",
-				"./custom_static/error.tmpl", "./custom_static/pass.tmpl", "./custom_static/privacy.tmpl",
-				"./custom_static/footer.tmpl", "./custom_static/head.tmpl", "./custom_static/nav.tmpl"),
-		)
+		http.Templates = template.Must(template.ParseGlob("./custom_static/*.tmpl"))
 	} else {
 		http.Templates = template.Must(template.ParseFS(embeddedStatic, "static/*.tmpl"))
 	}

--- a/test/http/front_test.go
+++ b/test/http/front_test.go
@@ -85,11 +85,7 @@ func (suite frontTestSuite) TestRenderTemplate() {
 }
 
 func (suite frontTestSuite) TestMainFrontHandlers() { //nolint:funlen
-	HTTP.Templates = template.Must(
-		template.ParseFiles("../../static/index.tmpl", "../../static/add.tmpl",
-			"../../static/error.tmpl", "../../static/pass.tmpl", "../../static/privacy.tmpl",
-			"../../static/footer.tmpl", "../../static/head.tmpl", "../../static/nav.tmpl"),
-	)
+	HTTP.Templates = template.Must(template.ParseGlob("../../static/*.tmpl"))
 
 	testEnv := env.GetEnv("../.env.test")
 	testEnv.DBURL = "front_test.db"


### PR DESCRIPTION
# Description

Add the ability include an infinite number templates instead of the hard-coded templates using template.ParseGlob.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

Please delete options that are not relevant.

- [x] I've read the [contribution guidelines](https://github.com/redds-be/reddlinks/blob/main/README.md#contributing)
- [x] I did `make prep` before submitting the PR, which resulted in no test or linting errors or warnings
- [x] I've checked that the test suite isn't broken