### PR TITLE
Add shortened link info page

### DIFF
--- a/internal/database/links.go
+++ b/internal/database/links.go
@@ -121,7 +121,18 @@ func CreateLink(
 	return err
 }
 
-// GetURLByShort gets a link entry from the links table by its value of the short column.
+// GetURLInfo gets a link entry from the links table by its value of the short column.
+func GetURLInfo(db *sql.DB, short string) (string, time.Time, time.Time, error) {
+	sqlGetURLByShort := `SELECT url, created_at, expire_at FROM links WHERE short = $1;`
+	var url string
+	var createdAt time.Time
+	var expireAt time.Time
+	err := db.QueryRow(sqlGetURLByShort, short).Scan(&url, &createdAt, &expireAt)
+
+	return url, createdAt, expireAt, err
+}
+
+// GetURLByShort gets the URL associated to the given short.
 func GetURLByShort(db *sql.DB, short string) (string, error) {
 	sqlGetURLByShort := `SELECT url FROM links WHERE short = $1;`
 	var url string

--- a/internal/json/json.go
+++ b/internal/json/json.go
@@ -29,6 +29,14 @@ type ErrResponse struct {
 	Error string `json:"error"`
 }
 
+// InfoResponse defines a JSON structure for info on a shortened url.
+type InfoResponse struct {
+	DstURL    string `json:"dstUrl"`
+	Short     string `json:"short"`
+	CreatedAt string `json:"createdAt"`
+	ExpiresAt string `json:"expiresAt"`
+}
+
 // RespondWithError sends the JSON the client along with the error code.
 func RespondWithError(writer http.ResponseWriter, code int, msg string) {
 	RespondWithJSON(writer, code, ErrResponse{Error: fmt.Sprintf("%d %s", code, msg)})

--- a/static/en/info.en.tmpl
+++ b/static/en/info.en.tmpl
@@ -19,15 +19,13 @@
 {{template "head.en.tmpl" .}}
 {{template "nav.en.tmpl" .}}
 <div class="main">
-    <p>This link requires a password</p>
-    <form action="/access" method="post">
+    <p>Destination URL: {{.DstURL}}</p>
+    <p>Short: {{.Short}}</p>
+    <p>Date of creation: {{.CreationDate}}</p>
+    <p>Date of expiration: {{.ExpirationDate}}</p>
+    <form action="/" method="Get">
         <div class="div-input">
-                <input placeholder="&bull;&bull;&bull;&bull;&bull;&bull;&bull;&bull;" name="password" title="Password" class="oth-input" type="password" required>
-        </div>
-        <input type="hidden" name="short" value="{{.Short}}">
-        <input type="hidden" name="info" value="{{.InfoRequest}}">
-        <div class="div-input">
-            <button value="Access" name="access" type="submit">Access the link</button>
+            <a class="button" href="{{.DstURL}}">Proceed</a>
         </div>
     </form>
 </div>

--- a/static/fr/info.fr.tmpl
+++ b/static/fr/info.fr.tmpl
@@ -19,15 +19,13 @@
 {{template "head.en.tmpl" .}}
 {{template "nav.en.tmpl" .}}
 <div class="main">
-    <p>This link requires a password</p>
-    <form action="/access" method="post">
+    <p>Destination URL : {{.DstURL}}</p>
+    <p>Short : {{.Short}}</p>
+    <p>Date de création : {{.CreationDate}}</p>
+    <p>Date d'expiration : {{.ExpirationDate}}</p>
+    <form action="/" method="Get">
         <div class="div-input">
-                <input placeholder="&bull;&bull;&bull;&bull;&bull;&bull;&bull;&bull;" name="password" title="Password" class="oth-input" type="password" required>
-        </div>
-        <input type="hidden" name="short" value="{{.Short}}">
-        <input type="hidden" name="info" value="{{.InfoRequest}}">
-        <div class="div-input">
-            <button value="Access" name="access" type="submit">Access the link</button>
+            <a class="button" href="{{.DstURL}}">Accéder à la destination</a>
         </div>
     </form>
 </div>

--- a/static/fr/pass.fr.tmpl
+++ b/static/fr/pass.fr.tmpl
@@ -25,6 +25,7 @@
                 <input placeholder="&bull;&bull;&bull;&bull;&bull;&bull;&bull;&bull;" name="password" title="Password" class="oth-input" type="password" required>
         </div>
         <input type="hidden" name="short" value="{{.Short}}">
+        <input type="hidden" name="info" value="{{.InfoRequest}}">
         <div class="div-input">
             <button value="Access" name="access" type="submit">Accéder au lien</button>
         </div>

--- a/test/http/front_test.go
+++ b/test/http/front_test.go
@@ -157,7 +157,7 @@ func (suite frontTestSuite) TestMainFrontHandlers() { //nolint:funlen
 	req.Header.Set("Accept-Language", "en-US,en;q=0.5")
 	resp = httptest.NewRecorder()
 
-	httpAdapter.FrontAskForPassword(resp, req)
+	httpAdapter.FrontAskForPassword(resp, req, false)
 
 	suite.a.Assert(resp.Code, http.StatusOK)
 
@@ -211,6 +211,23 @@ func (suite frontTestSuite) TestMainFrontHandlers() { //nolint:funlen
 	httpAdapter.FrontHandlerRedirectToURL(resp, req)
 
 	suite.a.Assert(resp.Code, http.StatusNotFound)
+
+	// Test getting shortened link information
+	redirectForm = url.Values{
+		"access":   {"Access"},
+		"short":    {"addpagetest"},
+		"info":     {"true"},
+		"password": {"secret"},
+	}
+
+	req = httptest.NewRequest(http.MethodPost, "/pass", strings.NewReader(redirectForm.Encode()))
+	req.Header.Set("Accept-Language", "en-US,en;q=0.5")
+	resp = httptest.NewRecorder()
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	httpAdapter.FrontHandlerRedirectToURL(resp, req)
+
+	suite.a.Assert(resp.Code, http.StatusOK)
 }
 
 // Test suite structure.


### PR DESCRIPTION
# Description

If the suffix '+' is used at then end of a shortened path, an information page will be displayed. Password protection is not bypassed.

For CLI clients, a JSON response is given, for browsers, an HTML response is given.

Added a function to get url, creation date and expiration date of a given short from the database.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update
- [x] This change modifies the test suite

# Checklist:

- [x] I've read the [contribution guidelines](https://github.com/redds-be/reddlinks/blob/main/README.md#contributing)
- [x] I did `make prep` before submitting the PR, which resulted in no test or linting errors or warnings
- [x] I've checked that the test suite isn't broken
- [x] I've created tests for the new functions I've added
- [x] I've added documentation comments