### PR TITLE
Fix redirection loops

### DIFF
--- a/internal/links/links.go
+++ b/internal/links/links.go
@@ -186,6 +186,14 @@ func (conf Configuration) CreateLink( //nolint:funlen,gocognit,cyclop,gocyclo
 		params.Path = params.Path[:conf.DefaultMaxCustomLength]
 	}
 
+	// Check for an attempt at creating a redirection loop, error if that's the case
+	if regexp.MustCompile("^https://|http://").
+		ReplaceAllString(params.URL, "") ==
+		regexp.MustCompile("^https://|http://").
+			ReplaceAllString(fmt.Sprintf("%s%s", conf.InstanceURL, params.Path), "") {
+		return Link{}, http.StatusBadRequest, "", "Could not create a redirection loop."
+	}
+
 	// If the password given to by the request isn't null (meaning no password), generate an argon2 hash from it
 	hash := ""
 	if params.Password != "" {

--- a/test/http/api_test.go
+++ b/test/http/api_test.go
@@ -416,6 +416,28 @@ func (suite apiTestSuite) TestMainAPIHandlers() { //nolint:funlen,maintidx
 	mux.ServeHTTP(resp, req)
 
 	suite.a.Assert(resp.Code, http.StatusNotFound)
+
+	// Test redirection loop creation
+	params = utils.Parameters{
+		URL:         "http://127.0.0.1:8080/loop",
+		Length:      0,
+		Path:        "loop",
+		ExpireAfter: "",
+		Password:    "",
+	}
+
+	err = json.NewEncoder(&buf).Encode(params)
+	suite.a.AssertNoErr(err)
+
+	req = httptest.NewRequest(http.MethodPost, "/", &buf)
+	resp = httptest.NewRecorder()
+	mux.ServeHTTP(resp, req)
+
+	suite.a.Assert(resp.Code, http.StatusBadRequest)
+	suite.a.Assert(
+		resp.Body.String(),
+		"{\"error\":\"400 Could not create a redirection loop.\"}",
+	)
 }
 
 // Test suite structure.

--- a/test/links/links_test.go
+++ b/test/links/links_test.go
@@ -180,6 +180,20 @@ func (suite linksTestSuite) TestCreateLink() { //nolint:funlen
 
 	suite.a.Assert(errMsg, "The URL is invalid.")
 	suite.a.Assert(code, http.StatusBadRequest)
+
+	// Test redirection loop creation
+	params = utils.Parameters{
+		URL:         "http://127.0.0.1:8080/loop",
+		Length:      0,
+		Path:        "loop",
+		ExpireAfter: "",
+		Password:    "",
+	}
+
+	_, code, _, errMsg = linksAdapter.CreateLink(params)
+
+	suite.a.Assert(errMsg, "Could not create a redirection loop.")
+	suite.a.Assert(code, http.StatusBadRequest)
 }
 
 // Test suite structure.


### PR DESCRIPTION
# Description

Check for a redirection loop before creating a shortened link, already created redirection loops are unaffected.

Would fix an issue if people created issues instead of directly messaging me...

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change modifies the test suite

# Checklist:

- [x] I've read the [contribution guidelines](https://github.com/redds-be/reddlinks/blob/main/README.md#contributing)
- [x] I did `make prep` before submitting the PR, which resulted in no test or linting errors or warnings
- [x] I've checked that the test suite isn't broken
- [x] I've created tests for the new functions I've added
- [x] I've added documentation comments